### PR TITLE
Fix ch.7 callout + data.frame naming (D1/D4)

### DIFF
--- a/02-linear-models.qmd
+++ b/02-linear-models.qmd
@@ -103,8 +103,8 @@ Although a line of best fit can always be calculated, the line might not be wort
 
 ```{r}
 more_df <- data.frame(
-  x <- runif(20, 5, 15),
-  y <- runif(20, 5, 15)
+  x = runif(20, 5, 15),
+  y = runif(20, 5, 15)
 )
 
 its_plot_xy_time(more_df)

--- a/02-linear-models.qmd
+++ b/02-linear-models.qmd
@@ -116,7 +116,7 @@ We can definitely calculate a line that fits these,
 lm(y ~ x, data = more_df)
 ```
 
-and it would be $y = 0.1103x + 10.6495$. But if we compare the fit of those lines, like in these plots 
+and it would be $y = 0.1103x + 10.4695$. But if we compare the fit of those lines, like in these plots 
 
 ```{r, echo=FALSE}
 #| layout-ncol: 2

--- a/07-testing_model.qmd
+++ b/07-testing_model.qmd
@@ -46,8 +46,8 @@ Another thing you can do to assess your linear model is check out the residuals.
 #| layout-ncol: 2
 close_fit <- its_random_xy_time(20)
 far_fit <- data.frame(
-  x <- runif(20, 5, 15),
-  y <- runif(20, 5, 15)
+  x = runif(20, 5, 15),
+  y = runif(20, 5, 15)
 )
 
 its_plot_xy_time(close_fit, line = TRUE)
@@ -116,4 +116,4 @@ plot(non_linear_model, which = 2)
 :::{.callout-note}
 ## Roundup
   * Linear models work best when the residuals are normally distributed, but linear models are somewhat robust to deviation from this
-```
+:::


### PR DESCRIPTION
Phase 0, Group D — two render-checked fixes. Targets the integration branch (master frozen).

- **#12** `07-testing_model.qmd`: the final Roundup callout was never closed — a stray ``` ``` ``` truncated the chapter. Replaced with `:::`.
- **#15** ch.2 (`more_df`) & ch.7 (`far_fit`): `data.frame(x <- runif(...), y <- runif(...))` → `data.frame(x = ..., y = ...)`. The old form mis-named the columns and only worked because `x`/`y` leaked into the global env; downstream `lm(y ~ x)`, `its_plot_xy_time()`, and `aes(sample = y)` now bind to real columns.

Render-checked ch.2 and ch.7 locally (clean). Non-default base → close #12/#15 manually on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)