### PR TITLE
Drop the PDF download button

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -7,7 +7,6 @@ book:
   author: "Dan MacLean"
   date: "June 2026"
   search: true
-  downloads: [pdf]
   sharing: [twitter, facebook]
   chapters: 
     - index.qmd
@@ -63,7 +62,5 @@ format:
   live-html:
     theme: cosmo
     css: webr-ui.css
-  pdf:
-    documentclass: scrreprt
 comments:
   hypothesis: true


### PR DESCRIPTION
The live site serves via `publish.yml --to live-html`, so the PDF was never built and the download button 404'd. Removed `downloads: [pdf]` and the unused `pdf` format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)